### PR TITLE
Send order note close #90

### DIFF
--- a/includes/class-dropshipping-wc-mp-orders.php
+++ b/includes/class-dropshipping-wc-mp-orders.php
@@ -207,7 +207,7 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		$request->set_param( 'id', $order_id );
 		$result  = $controller->get_item( $request );
 		$order   = isset( $result->data ) ? $result->data : array();
-		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl' );
+		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl', 'customer_note' );
 		$item_whitelist_fields = array( 'id', 'sku', 'quantity' );
 		$new_order = array();
 
@@ -275,6 +275,7 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		// Add Email and phone into Shipping.
 		$new_order['shipping']['email'] = $new_order['billing']['email'];
 		$new_order['shipping']['phone'] = $new_order['billing']['phone'];
+		$new_order['notes'] = $new_order['customer_note'];
 
 		if ( $json ) {
 			$new_order = wp_json_encode( $new_order );

--- a/includes/class-dropshipping-wc-mp-orders.php
+++ b/includes/class-dropshipping-wc-mp-orders.php
@@ -207,12 +207,12 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		$request->set_param( 'id', $order_id );
 		$result  = $controller->get_item( $request );
 		$order   = isset( $result->data ) ? $result->data : array();
-		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl', 'customer_note' );
+		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl' );
 		$item_whitelist_fields = array( 'id', 'sku', 'quantity' );
 		$new_order = array();
 
-		$search_order  = array( 'line_items', 'pdf_invoice_url', 'pdf_invoice_url_rtl' );
-		$replace_order = array( 'items', 'invoice_url', 'invoice_url_rtl' );
+		$search_order  = array( 'line_items', 'pdf_invoice_url', 'pdf_invoice_url_rtl', 'customer_note' );
+		$replace_order = array( 'items', 'invoice_url', 'invoice_url_rtl', 'notes' );
 		foreach ( $order as $key => $value ) {
 			if ( in_array( $key, $order_whitelist_fields ) ) {
 
@@ -275,7 +275,6 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		// Add Email and phone into Shipping.
 		$new_order['shipping']['email'] = $new_order['billing']['email'];
 		$new_order['shipping']['phone'] = $new_order['billing']['phone'];
-		$new_order['notes'] = $new_order['customer_note'];
 
 		if ( $json ) {
 			$new_order = wp_json_encode( $new_order );


### PR DESCRIPTION
Send order notes along with Knawat sales order from dropshipping-woocommerce plugin.
Please check this documentation for more information on how to send order from Woocommerce to Knawat: https://docs.woocommerce.com/wc-apidocs/class-WC_Order.html

Steps to test this issue:
1- Download Xampp or any localhost server hosting on your local machine.
2- Download and install Wordpress, Woocommerce, qtranslate-x and all other important plugins that Woocommerce needs to work as expected.
3- Download Knawat Dropshipping plugin and also download recommended plugins by Knawat.
4- Import products into your store.
5- Try to make a sales order whether from the admin panel or from as a regular customer and add a note to the sales order.
6- After making your sales order in processing status, check Knawat sales order created and note added or not.