### PR TITLE
Import categories as tags close #112

### DIFF
--- a/includes/class-dropshipping-wc-mp-orders.php
+++ b/includes/class-dropshipping-wc-mp-orders.php
@@ -207,7 +207,7 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		$request->set_param( 'id', $order_id );
 		$result  = $controller->get_item( $request );
 		$order   = isset( $result->data ) ? $result->data : array();
-		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl' );
+		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl', 'customer_note' );
 		$item_whitelist_fields = array( 'id', 'sku', 'quantity' );
 		$new_order = array();
 
@@ -275,6 +275,7 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		// Add Email and phone into Shipping.
 		$new_order['shipping']['email'] = $new_order['billing']['email'];
 		$new_order['shipping']['phone'] = $new_order['billing']['phone'];
+		$new_order['notes'] = $new_order['customer_note'];
 
 		if ( $json ) {
 			$new_order = wp_json_encode( $new_order );

--- a/includes/class-dropshipping-wc-mp-orders.php
+++ b/includes/class-dropshipping-wc-mp-orders.php
@@ -207,12 +207,12 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		$request->set_param( 'id', $order_id );
 		$result  = $controller->get_item( $request );
 		$order   = isset( $result->data ) ? $result->data : array();
-		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl', 'customer_note' );
+		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl' );
 		$item_whitelist_fields = array( 'id', 'sku', 'quantity' );
 		$new_order = array();
 
-		$search_order  = array( 'line_items', 'pdf_invoice_url', 'pdf_invoice_url_rtl' );
-		$replace_order = array( 'items', 'invoice_url', 'invoice_url_rtl' );
+		$search_order  = array( 'line_items', 'pdf_invoice_url', 'pdf_invoice_url_rtl', 'customer_note' );
+		$replace_order = array( 'items', 'invoice_url', 'invoice_url_rtl', 'notes' );
 		foreach ( $order as $key => $value ) {
 			if ( in_array( $key, $order_whitelist_fields ) ) {
 
@@ -275,7 +275,6 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		// Add Email and phone into Shipping.
 		$new_order['shipping']['email'] = $new_order['billing']['email'];
 		$new_order['shipping']['phone'] = $new_order['billing']['phone'];
-		$new_order['notes'] = $new_order['customer_note'];
 
 		if ( $json ) {
 			$new_order = wp_json_encode( $new_order );

--- a/includes/class-dropshipping-woocommerce-importer.php
+++ b/includes/class-dropshipping-woocommerce-importer.php
@@ -359,7 +359,8 @@ if (class_exists('WC_Product_Importer', false)) :
 					}
 				}
 			}
-			$new_product['tag_ids'] = array();
+			$new_product['tags'] = array();
+			if ($active_plugins['qtranslate-x'] && !empty($active_langs)){
 				foreach($product->categories as $category){
 					foreach($active_langs as $active_lang){
 						if(isset($category->name->$active_lang)){
@@ -369,10 +370,17 @@ if (class_exists('WC_Product_Importer', false)) :
 					if($tag != ''){
 						$tag .= '[:]';
 					}
-					array_push($new_product['tag_ids'], $tag);
+					array_push($new_product['tags'], $tag);
 					unset($tag);
 				}
-				wp_set_object_terms(!empty($new_product['id'])? $new_product['id'] : 0, $new_product['tag_ids'], 'product_tag', true);
+			}else{
+				foreach($product->categories as $category){
+					$tag .= isset($category->name->$default_lang)? sanitize_text_field($category->name->$default_lang) : '';
+					array_push($new_product['tags'], $tag);
+					unset($tag);
+				}
+			}
+			wp_set_object_terms(!empty($new_product['id'])? $new_product['id'] : 0, $new_product['tags'], 'product_tag', true);
 
 			$variations = array();
 			$var_attributes = array();

--- a/includes/class-dropshipping-woocommerce-importer.php
+++ b/includes/class-dropshipping-woocommerce-importer.php
@@ -359,6 +359,20 @@ if (class_exists('WC_Product_Importer', false)) :
 					}
 				}
 			}
+			$new_product['tag_ids'] = array();
+				foreach($product->categories as $category){
+					foreach($active_langs as $active_lang){
+						if(isset($category->name->$active_lang)){
+							$tag .= '[:' . $active_lang . ']' . $category->name->$active_lang;
+						}
+					}
+					if($tag != ''){
+						$tag .= '[:]';
+					}
+					array_push($new_product['tag_ids'], $tag);
+					unset($tag);
+				}
+				$result_tag = wp_set_object_terms(!empty($new_product['id'])? $new_product['id'] : 0, $new_product['tag_ids'], 'product_tag', true);
 
 			$variations = array();
 			$var_attributes = array();

--- a/includes/class-dropshipping-woocommerce-importer.php
+++ b/includes/class-dropshipping-woocommerce-importer.php
@@ -372,7 +372,7 @@ if (class_exists('WC_Product_Importer', false)) :
 					array_push($new_product['tag_ids'], $tag);
 					unset($tag);
 				}
-				$result_tag = wp_set_object_terms(!empty($new_product['id'])? $new_product['id'] : 0, $new_product['tag_ids'], 'product_tag', true);
+				wp_set_object_terms(!empty($new_product['id'])? $new_product['id'] : 0, $new_product['tag_ids'], 'product_tag', true);
 
 			$variations = array();
 			$var_attributes = array();

--- a/templates/admin/dropshipping-woocommerce-import.php
+++ b/templates/admin/dropshipping-woocommerce-import.php
@@ -6,6 +6,17 @@ $consumer_keys = knawat_dropshipwc_get_consumerkeys();
 if( empty( $consumer_keys ) ){
 	?>
 	<div class="knawat_dropshipwc_import">
+		<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-XXXX');</script>
+		<!-- End Google Tag Manager -->
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 		<p>
 			<?php printf( __( 'Please insert Knawat Consumer Key and Consumer Secret in <a href="%s">Settings</a> tab.','dropshipping-woocommerce' ), esc_url( add_query_arg( 'tab', 'settings', admin_url('admin.php?page=knawat_dropship' ) ) ) ); ?></p>
 	</div>
@@ -16,6 +27,17 @@ if( empty( $consumer_keys ) ){
 	$token_status = isset( $knawat_options['token_status'] ) ? esc_attr( $knawat_options['token_status'] ) : 'invalid';
 	?>
 	<div class="knawat_dropshipwc_import">
+		<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-XXXX');</script>
+		<!-- End Google Tag Manager -->
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<h3><?php esc_attr_e( 'Product Import', 'dropshipping-woocommerce' ); ?></h3>
 		<p><?php _e( 'Plugin auto import/update products from knawat.com in background on regular interval. But, if you want then you can manually start import.','dropshipping-woocommerce' ); ?></p>


### PR DESCRIPTION
Description:
Import Updated product categories as tags and add them to the tags section and assign them to the product being updated.

Steps to test this issue:
1- Download Xampp or any localhost server hosting on your local machine.
2- Download and install Wordpress, Woocommerce, qtranslate-x and all other important plugins that Woocommerce needs to work as expected.
3- Download Knawat Dropshipping plugin and also download recommended plugins by Knawat.
4- Import products into your store.
5- Go to all products page and try to see if the tags section in every product is filled with Knawat categories as Tags.
6- Go to the tags section in Woocommerce and try to see if tags already exist with its translations or not.

Reason for not working according to the first acceptance criteria:
The product id doesn't get created until it gets passed in process_item function and function wp_set_object_terms gets called in formatting the product function before process_item function and since there is no ID related to the new product, the tag relation won't be attached to the product.
Another reason is that process_item function doesn't handle tag adding in importing new products but in update existing products.