### PR TITLE
Add option force update for Single Product and Product List close #25

### DIFF
--- a/includes/class-dropshipping-wc-async-request.php
+++ b/includes/class-dropshipping-wc-async-request.php
@@ -66,7 +66,7 @@ class Knawat_Dropshipping_WC_Async_Request extends WP_Async_Request {
 		$sku = isset( $_POST['sku'] ) ? sanitize_text_field( $_POST['sku'] ) : '';
 		if( $sku != '' ){
 			global $knawat_dropshipwc;
-			$updated = $knawat_dropshipwc->common->knawat_dropshipwc_import_product_by_sku( $sku );
+			$updated = $knawat_dropshipwc->common->knawat_dropshipwc_import_product_by_sku( $sku , true );
 		}
 	}
 }

--- a/includes/class-dropshipping-wc-mp-orders.php
+++ b/includes/class-dropshipping-wc-mp-orders.php
@@ -207,7 +207,7 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		$request->set_param( 'id', $order_id );
 		$result  = $controller->get_item( $request );
 		$order   = isset( $result->data ) ? $result->data : array();
-		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl' );
+		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl', 'customer_note' );
 		$item_whitelist_fields = array( 'id', 'sku', 'quantity' );
 		$new_order = array();
 
@@ -275,6 +275,7 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		// Add Email and phone into Shipping.
 		$new_order['shipping']['email'] = $new_order['billing']['email'];
 		$new_order['shipping']['phone'] = $new_order['billing']['phone'];
+		$new_order['notes'] = $new_order['customer_note'];
 
 		if ( $json ) {
 			$new_order = wp_json_encode( $new_order );

--- a/includes/class-dropshipping-wc-mp-orders.php
+++ b/includes/class-dropshipping-wc-mp-orders.php
@@ -207,12 +207,12 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		$request->set_param( 'id', $order_id );
 		$result  = $controller->get_item( $request );
 		$order   = isset( $result->data ) ? $result->data : array();
-		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl', 'customer_note' );
+		$order_whitelist_fields = array( 'id', 'parent_id', 'number', 'order_key', 'created_via', 'currency', 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax','total','total_tax','prices_include_tax', 'customer_note', 'transaction_id', 'status', 'line_items', 'billing', 'shipping', 'pdf_invoice_url', 'pdf_invoice_url_rtl' );
 		$item_whitelist_fields = array( 'id', 'sku', 'quantity' );
 		$new_order = array();
 
-		$search_order  = array( 'line_items', 'pdf_invoice_url', 'pdf_invoice_url_rtl' );
-		$replace_order = array( 'items', 'invoice_url', 'invoice_url_rtl' );
+		$search_order  = array( 'line_items', 'pdf_invoice_url', 'pdf_invoice_url_rtl', 'customer_note' );
+		$replace_order = array( 'items', 'invoice_url', 'invoice_url_rtl', 'notes' );
 		foreach ( $order as $key => $value ) {
 			if ( in_array( $key, $order_whitelist_fields ) ) {
 
@@ -275,7 +275,6 @@ class Knawat_Dropshipping_WC_MP_Orders {
 		// Add Email and phone into Shipping.
 		$new_order['shipping']['email'] = $new_order['billing']['email'];
 		$new_order['shipping']['phone'] = $new_order['billing']['phone'];
-		$new_order['notes'] = $new_order['customer_note'];
 
 		if ( $json ) {
 			$new_order = wp_json_encode( $new_order );

--- a/includes/class-dropshipping-woocommerce-common.php
+++ b/includes/class-dropshipping-woocommerce-common.php
@@ -193,7 +193,7 @@ class Knawat_Dropshipping_Woocommerce_Common {
 	 *
 	 * @since 2.0.0
 	 */
-	public function knawat_dropshipwc_before_single_product(){
+	public static function knawat_dropshipwc_before_single_product(){
 		$product_id = get_the_ID();
 		if( empty( $product_id ) ){
 			return;

--- a/includes/class-dropshipping-woocommerce-common.php
+++ b/includes/class-dropshipping-woocommerce-common.php
@@ -31,6 +31,8 @@ class Knawat_Dropshipping_Woocommerce_Common {
 		add_action( 'before_delete_post', array( $this, 'knawat_delete_product_on_mp' ) );
 		add_action( 'wp_trash_post', array( $this, 'knawat_show_notice_for_delete' ) );
 		add_action( 'add_meta_boxes_product', array($this, 'knawat_dropshipwc_add_metabox_update'));
+		add_filter( 'bulk_actions-edit-product', array($this, 'knawatproduct_after_loop'), 1000);
+		add_filter( 'handle_bulk_actions-edit-product', array($this, 'knawat_update_post_product'), 10, 3);
 	}
 
 	/**
@@ -437,6 +439,22 @@ class Knawat_Dropshipping_Woocommerce_Common {
 	function knawatproduct_render_metabox(){
 		include KNAWAT_DROPWC_PLUGIN_DIR . 'templates/products/edit_product.php';
 		knawatproduct_metabox();
+	}
+	function knawatproduct_after_loop($bulk_array){
+		$bulk_array['knawat_update'] = 'Knawat Update';
+		return $bulk_array;
+	}
+	function knawat_update_post_product($redirect, $doaction, $object_ids){
+		//remove query args from URL first
+		$redirect = remove_query_arg(array('knawat_update_done'), $redirect);
+		//Update Products from Knawat MP
+		if ($doaction == 'knawat_update'){
+			foreach( $object_ids as $post_id){
+				$this->knawat_dropshipwc_async_product_update_by_id($post_id);
+			}
+			$redirect = add_query_arg('knawat_update_done', count($object_ids), $redirect);
+		}
+		return $redirect;
 	}
 }
 

--- a/includes/class-dropshipping-woocommerce-common.php
+++ b/includes/class-dropshipping-woocommerce-common.php
@@ -241,7 +241,7 @@ class Knawat_Dropshipping_Woocommerce_Common {
 	 *
 	 * @since 2.0.0
 	 */
-	function knawat_dropshipwc_import_product_by_sku( $sku, $force_update = true ){
+	function knawat_dropshipwc_import_product_by_sku( $sku, $force_update = false ){
 		if( empty( $sku ) ){
 			return false;
 		}

--- a/includes/class-dropshipping-woocommerce-common.php
+++ b/includes/class-dropshipping-woocommerce-common.php
@@ -30,6 +30,7 @@ class Knawat_Dropshipping_Woocommerce_Common {
 		add_action( 'wp_ajax_knawat_dismiss_admin_notice', array( $this, 'knawat_dismiss_admin_notice' ) );
 		add_action( 'before_delete_post', array( $this, 'knawat_delete_product_on_mp' ) );
 		add_action( 'wp_trash_post', array( $this, 'knawat_show_notice_for_delete' ) );
+		add_action( 'add_meta_boxes_product', array($this, 'knawat_dropshipwc_add_metabox_update'));
 	}
 
 	/**
@@ -192,11 +193,12 @@ class Knawat_Dropshipping_Woocommerce_Common {
 	 */
 	public function knawat_dropshipwc_before_single_product(){
 		$product_id = get_the_ID();
+		error_log("ID: " . $product_id);
 		if( empty( $product_id ) ){
 			return;
 		}
 		// Update product
-		$this->knawat_dropshipwc_async_product_update_by_id( $product_id );
+		Knawat_Dropshipping_Woocommerce_Common:: knawat_dropshipwc_async_product_update_by_id( $product_id );
 	}
 
 	/**
@@ -416,6 +418,23 @@ class Knawat_Dropshipping_Woocommerce_Common {
 				knawat_set_notices($messages);
 			}
 		}
+	}
+	/**
+	 * Add Product update in product edit page
+	 * @return void.
+	 */
+	function knawat_dropshipwc_add_metabox_update(){
+		add_meta_box('knawatproduct_metabox',
+						__('Knawat Dropshipping', 'dropshipping-woocommerce'),
+						array($this, 'knawatproduct_render_metabox'),
+						'product',
+						'side',
+						'high'
+					);
+	}
+	function knawatproduct_render_metabox(){
+		include KNAWAT_DROPWC_PLUGIN_DIR . 'templates/products/edit_product.php';
+		knawatproduct_metabox();
 	}
 }
 

--- a/includes/class-dropshipping-woocommerce-common.php
+++ b/includes/class-dropshipping-woocommerce-common.php
@@ -437,7 +437,7 @@ class Knawat_Dropshipping_Woocommerce_Common {
 		}
 	}
 	function knawatproduct_render_metabox(){
-		include KNAWAT_DROPWC_PLUGIN_DIR . 'templates/products/edit_product.php';
+		include_once KNAWAT_DROPWC_PLUGIN_DIR . 'templates/products/edit_product.php';
 		knawatproduct_metabox();
 	}
 	function knawatproduct_after_loop($bulk_array){

--- a/includes/class-dropshipping-woocommerce-common.php
+++ b/includes/class-dropshipping-woocommerce-common.php
@@ -193,7 +193,6 @@ class Knawat_Dropshipping_Woocommerce_Common {
 	 */
 	public function knawat_dropshipwc_before_single_product(){
 		$product_id = get_the_ID();
-		error_log("ID: " . $product_id);
 		if( empty( $product_id ) ){
 			return;
 		}
@@ -240,7 +239,7 @@ class Knawat_Dropshipping_Woocommerce_Common {
 	 *
 	 * @since 2.0.0
 	 */
-	function knawat_dropshipwc_import_product_by_sku( $sku, $force_update = false ){
+	function knawat_dropshipwc_import_product_by_sku( $sku, $force_update = true ){
 		if( empty( $sku ) ){
 			return false;
 		}
@@ -424,13 +423,16 @@ class Knawat_Dropshipping_Woocommerce_Common {
 	 * @return void.
 	 */
 	function knawat_dropshipwc_add_metabox_update(){
-		add_meta_box('knawatproduct_metabox',
+		$product_id = get_the_ID();
+		if (knawat_dropshipwc_is_knawat_product($product_id)){
+			add_meta_box('knawatproduct_metabox',
 						__('Knawat Dropshipping', 'dropshipping-woocommerce'),
 						array($this, 'knawatproduct_render_metabox'),
 						'product',
 						'side',
 						'high'
 					);
+		}
 	}
 	function knawatproduct_render_metabox(){
 		include KNAWAT_DROPWC_PLUGIN_DIR . 'templates/products/edit_product.php';

--- a/includes/class-dropshipping-woocommerce-importer.php
+++ b/includes/class-dropshipping-woocommerce-importer.php
@@ -359,6 +359,20 @@ if (class_exists('WC_Product_Importer', false)) :
 					}
 				}
 			}
+			$new_product['tag_ids'] = array();
+				foreach($product->categories as $category){
+					foreach($active_langs as $active_lang){
+						if(isset($category->name->$active_lang)){
+							$tag .= '[:' . $active_lang . ']' . $category->name->$active_lang;
+						}
+					}
+					if($tag != ''){
+						$tag .= '[:]';
+					}
+					array_push($new_product['tag_ids'], $tag);
+					unset($tag);
+				}
+				$result_tag = wp_set_object_terms(!empty($new_product['id'])? $new_product['id'] : 0, $new_product['tag_ids'], 'product_tag', true);
 
 			$variations = array();
 			$var_attributes = array();

--- a/includes/class-dropshipping-woocommerce-importer.php
+++ b/includes/class-dropshipping-woocommerce-importer.php
@@ -372,7 +372,7 @@ if (class_exists('WC_Product_Importer', false)) :
 					array_push($new_product['tag_ids'], $tag);
 					unset($tag);
 				}
-				$result_tag = wp_set_object_terms(!empty($new_product['id'])? $new_product['id'] : 0, $new_product['tag_ids'], 'product_tag', true);
+				wp_set_object_terms(!empty($new_product['id'])? $new_product['id'] : 0, $new_product['tag_ids'], 'product_tag', true);
 
 			$variations = array();
 			$var_attributes = array();

--- a/templates/admin/dropshipping-woocommerce-import.php
+++ b/templates/admin/dropshipping-woocommerce-import.php
@@ -6,17 +6,6 @@ $consumer_keys = knawat_dropshipwc_get_consumerkeys();
 if( empty( $consumer_keys ) ){
 	?>
 	<div class="knawat_dropshipwc_import">
-		<!-- Google Tag Manager -->
-		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-		})(window,document,'script','dataLayer','GTM-PGD82MQ');</script>
-		<!-- End Google Tag Manager -->
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PGD82MQ"
-		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
 		<p>
 			<?php printf( __( 'Please insert Knawat Consumer Key and Consumer Secret in <a href="%s">Settings</a> tab.','dropshipping-woocommerce' ), esc_url( add_query_arg( 'tab', 'settings', admin_url('admin.php?page=knawat_dropship' ) ) ) ); ?></p>
 	</div>
@@ -27,18 +16,6 @@ if( empty( $consumer_keys ) ){
 	$token_status = isset( $knawat_options['token_status'] ) ? esc_attr( $knawat_options['token_status'] ) : 'invalid';
 	?>
 	<div class="knawat_dropshipwc_import">
-		<!-- Google Tag Manager -->
-		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-		})(window,document,'script','dataLayer','GTM-PGD82MQ');</script>
-		<!-- End Google Tag Manager -->
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PGD82MQ"
-		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
-
 		<h3><?php esc_attr_e( 'Product Import', 'dropshipping-woocommerce' ); ?></h3>
 		<p><?php _e( 'Plugin auto import/update products from knawat.com in background on regular interval. But, if you want then you can manually start import.','dropshipping-woocommerce' ); ?></p>
 		<table class="form-table">

--- a/templates/admin/dropshipping-woocommerce-import.php
+++ b/templates/admin/dropshipping-woocommerce-import.php
@@ -11,10 +11,10 @@ if( empty( $consumer_keys ) ){
 		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-		})(window,document,'script','dataLayer','GTM-XXXX');</script>
+		})(window,document,'script','dataLayer','GTM-PGD82MQ');</script>
 		<!-- End Google Tag Manager -->
 		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX"
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PGD82MQ"
 		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 		<!-- End Google Tag Manager (noscript) -->
 		<p>
@@ -32,10 +32,10 @@ if( empty( $consumer_keys ) ){
 		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-		})(window,document,'script','dataLayer','GTM-XXXX');</script>
+		})(window,document,'script','dataLayer','GTM-PGD82MQ');</script>
 		<!-- End Google Tag Manager -->
 		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX"
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PGD82MQ"
 		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 		<!-- End Google Tag Manager (noscript) -->
 

--- a/templates/admin/dropshipping-woocommerce-import.php
+++ b/templates/admin/dropshipping-woocommerce-import.php
@@ -6,6 +6,17 @@ $consumer_keys = knawat_dropshipwc_get_consumerkeys();
 if( empty( $consumer_keys ) ){
 	?>
 	<div class="knawat_dropshipwc_import">
+		<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-XXXX');</script>
+		<!-- End Google Tag Manager -->
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 		<p>
 			<?php printf( __( 'Please insert Knawat Consumer Key and Consumer Secret in <a href="%s">Settings</a> tab.','dropshipping-woocommerce' ), esc_url( add_query_arg( 'tab', 'settings', admin_url('admin.php?page=knawat_dropship' ) ) ) ); ?></p>
 	</div>
@@ -16,6 +27,17 @@ if( empty( $consumer_keys ) ){
 	$token_status = isset( $knawat_options['token_status'] ) ? esc_attr( $knawat_options['token_status'] ) : 'invalid';
 	?>
 	<div class="knawat_dropshipwc_import">
+		<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-XXXX');</script>
+		<!-- End Google Tag Manager -->
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<h3><?php esc_attr_e( 'Product Import', 'dropshipping-woocommerce' ); ?></h3>
 		<p><?php _e( 'Plugin auto import/update products from knawat.com in background on regular interval. But, if you want then you can manually start import.','dropshipping-woocommerce' ); ?></p>

--- a/templates/products/edit_product.php
+++ b/templates/products/edit_product.php
@@ -1,0 +1,24 @@
+<?php
+    /**
+     * Render Function for updating product in edit page
+     * @return void.
+     */
+    function knawatproduct_metabox(){
+?>
+        <dev id="knawatproduct-metabox-content">
+            <strong>Update Knawat Product</strong>
+            <p>Warning: any changes made to the product will be overwritten</p>
+            <a class="button button-primary button-large" id="knawat-update">Update</a>
+            <script>
+                jQuery("#knawat-update").click(function (e) {
+                    var x = window.location.href;
+                    x += '&knawat-update=true';
+                    document.getElementById('knawat-update').setAttribute('href', x);
+                });
+            </script>
+        </dev>
+<?php
+        if (isset($_GET['knawat-update']) && $_GET['knawat-update'] == true){
+            Knawat_Dropshipping_Woocommerce_Common:: knawat_dropshipwc_before_single_product();
+        }
+    }

--- a/templates/products/edit_product.php
+++ b/templates/products/edit_product.php
@@ -8,7 +8,7 @@
         <dev id="knawatproduct-metabox-content">
             <strong>Update Knawat Product</strong>
             <p>Warning: any changes made to the product will be overwritten</p>
-            <a class="button button-primary button-large" id="knawat-update">Update</a>
+            <a class="button button-secondary button-large" id="knawat-update">Get From Knawat</a>
             <script>
                 jQuery("#knawat-update").click(function (e) {
                     var x = window.location.href;
@@ -19,6 +19,16 @@
         </dev>
 <?php
         if (isset($_GET['knawat-update']) && $_GET['knawat-update'] == true){
-            Knawat_Dropshipping_Woocommerce_Common:: knawat_dropshipwc_before_single_product();
+            if (!isset($_GET['product-update'])){
+                Knawat_Dropshipping_Woocommerce_Common:: knawat_dropshipwc_before_single_product();
+                ?> <script>
+                        jQuery(document).ready(function(){
+                            var x = window.location.href;
+                            x+= '&product-update=finished';
+                            window.location.replace(x);
+                        });
+                    </script>
+                <?php
+            }
         }
     }


### PR DESCRIPTION
Description:
Added a part where the user can update a single product in the edit product page using Knawat button for updating.
Also, added a part where the user can select multiple products from the products list in Woocommerce and select Knawat Update from the bulk actions list and the products will be updated.

Steps to test this issue:
1- Download Xampp or any localhost server hosting on your local machine.
2- Download and install Wordpress, Woocommerce, qtranslate-x and all other important plugins that Woocommerce needs to work as expected.
3- Download Knawat Dropshipping plugin and also download recommended plugins by Knawat.
4- Import products into your store.
5- Go to the edit product page in any Knawat product and try to change its values then press update and you should see all these changes reverted to Knawat's original status and updating quantity and price if there is a change in them.
6- Go to all products page and select Knawat Update from bulk actions select box and click apply after that watch the magic happens.
Note: Update Multiple products in the products list might slow down your website speed so don't do it unless 100% sure. Or you can use Knawat dropshipping Plugin to update all products and not slow down Your store.