### PR TITLE
ADD: Force Update for single and list product/s close #25

### DIFF
--- a/includes/class-dropshipping-wc-async-request.php
+++ b/includes/class-dropshipping-wc-async-request.php
@@ -66,7 +66,7 @@ class Knawat_Dropshipping_WC_Async_Request extends WP_Async_Request {
 		$sku = isset( $_POST['sku'] ) ? sanitize_text_field( $_POST['sku'] ) : '';
 		if( $sku != '' ){
 			global $knawat_dropshipwc;
-			$updated = $knawat_dropshipwc->common->knawat_dropshipwc_import_product_by_sku( $sku );
+			$updated = $knawat_dropshipwc->common->knawat_dropshipwc_import_product_by_sku( $sku , true );
 		}
 	}
 }

--- a/templates/products/edit-product.php
+++ b/templates/products/edit-product.php
@@ -1,0 +1,33 @@
+<?php
+    /**
+     * Render Function for updating product in edit page
+     * @return void.
+     */
+    function knawatproduct_metabox(){
+?>
+        <dev id="knawatproduct-metabox-content">
+            <strong>Update Knawat Product</strong>
+            <p>Warning: any changes made to the product will be overwritten</p>
+            <a class="button button-secondary button-large" id="knawat-update">Get From Knawat</a>
+            <script>
+                jQuery("#knawat-update").click(function (e) {
+                    var x = window.location.href+'&knawat-update=true';
+                    document.getElementById('knawat-update').setAttribute('href', x);
+                });
+            </script>
+        </dev>
+<?php
+        if (isset($_GET['knawat-update']) && $_GET['knawat-update'] == true){
+            if (!isset($_GET['product-update'])){
+                global $knawat_dropshipwc;
+                $knawat_dropshipwc->common->knawat_dropshipwc_before_single_product();
+                ?> <script>
+                        jQuery(document).ready(function(){
+                            var x = window.location.href+'&product-update=finished';
+                            window.location.replace(x);
+                        });
+                    </script>
+                <?php
+            }
+        }
+    }


### PR DESCRIPTION
Description:
Added a part where the user can update a single product in the edit product page using the Knawat button for updating.
Also, added a part where the user can select multiple products from the products list in Woocommerce and select Knawat Update from the bulk actions list and the products will be updated.

Steps to test this issue:
1- Download Xampp or any localhost server hosting on your local machine.
2- Download and install WordPress, Woocommerce, qtranslate-x, and all other important plugins that Woocommerce needs to work as expected.
3- Download Knawat Dropshipping plugin and also download recommended plugins by Knawat.
4- Import products into your store.
5- Go to the edit product page in any Knawat product and try to change its values then press update and you should see all these changes reverted to Knawat's original status and updating quantity and price if there is a change in them.
6- Go to all products page and select Knawat Update from bulk actions select box and click apply after that watch the magic happens.
Note: Update Multiple products in the products list might slow down your website speed so don't do it unless 100% sure. Or you can use Knawat dropshipping Plugin to update all products and not slow down Your store.