### PR TITLE
Add an option to import categories as tags

### DIFF
--- a/includes/class-dropshipping-woocommerce-common.php
+++ b/includes/class-dropshipping-woocommerce-common.php
@@ -172,6 +172,14 @@ class Knawat_Dropshipping_Woocommerce_Common {
 				}
 			}
 
+			if ( isset( $knawatds_options['tagging_products'] ) ) {
+				if ( $knawatds_options['tagging_products'] == 'yes' ) {
+					$current_options['tagging_products'] = 'yes';
+				} else {
+					$current_options['tagging_products'] = 'no';
+				}
+			}
+
 			if ( isset( $knawatds_options['dokan_seller'] ) && is_numeric( $knawatds_options['dokan_seller'] ) ) {
 				$current_options['dokan_seller'] = sanitize_text_field( $knawatds_options['dokan_seller'] );
 			}

--- a/includes/class-dropshipping-woocommerce-common.php
+++ b/includes/class-dropshipping-woocommerce-common.php
@@ -165,18 +165,18 @@ class Knawat_Dropshipping_Woocommerce_Common {
 			}
 
 			if ( isset( $knawatds_options['categorize_products'] ) ) {
-				if ( $knawatds_options['categorize_products'] == 'yes' ) {
-					$current_options['categorize_products'] = 'yes';
+				if ( $knawatds_options['categorize_products'] == 'true' ) {
+					$current_options['categorize_products'] = 'true';
 				} else {
-					$current_options['categorize_products'] = 'no';
+					$current_options['categorize_products'] = 'false';
 				}
 			}
 
 			if ( isset( $knawatds_options['tagging_products'] ) ) {
-				if ( $knawatds_options['tagging_products'] == 'yes' ) {
-					$current_options['tagging_products'] = 'yes';
+				if ( $knawatds_options['tagging_products'] == 'true' ) {
+					$current_options['tagging_products'] = 'true';
 				} else {
-					$current_options['tagging_products'] = 'no';
+					$current_options['tagging_products'] = 'false';
 				}
 			}
 

--- a/includes/class-dropshipping-woocommerce-importer.php
+++ b/includes/class-dropshipping-woocommerce-importer.php
@@ -362,6 +362,7 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 			}
 			$knawat_options      = knawat_dropshipwc_get_options();
 			$categorize_products = isset( $knawat_options['categorize_products'] ) ? esc_attr( $knawat_options['categorize_products'] ) : 'no';
+			$tagging_products = isset( $knawat_options['tagging_products'] ) ? esc_attr( $knawat_options['tagging_products'] ) : 'no';
 			$new_product['tags'] = array();
 			$cat_id              = null;
 			$tag = '';
@@ -425,7 +426,9 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 					unset( $tag );
 				}
 			}
-			wp_set_object_terms( ! empty( $new_product['id'] ) ? $new_product['id'] : 0, $new_product['tags'], 'product_tag', true );
+			if ($tagging_products === 'yes'){
+				wp_set_object_terms( ! empty( $new_product['id'] ) ? $new_product['id'] : 0, $new_product['tags'], 'product_tag', true );
+			}
 
 			$variations     = array();
 			$var_attributes = array();

--- a/includes/class-dropshipping-woocommerce-importer.php
+++ b/includes/class-dropshipping-woocommerce-importer.php
@@ -361,8 +361,8 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 				}
 			}
 			$knawat_options      = knawat_dropshipwc_get_options();
-			$categorize_products = isset( $knawat_options['categorize_products'] ) ? esc_attr( $knawat_options['categorize_products'] ) : 'no';
-			$tagging_products = isset( $knawat_options['tagging_products'] ) ? esc_attr( $knawat_options['tagging_products'] ) : 'no';
+			$categorize_products = isset( $knawat_options['categorize_products'] ) ? esc_attr( $knawat_options['categorize_products'] ) : 'false';
+			$tagging_products = isset( $knawat_options['tagging_products'] ) ? esc_attr( $knawat_options['tagging_products'] ) : 'false';
 			$new_product['tags'] = array();
 			$cat_id              = null;
 			$tag = '';
@@ -377,7 +377,7 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 						$tag .= '[:]';
 					}
 
-					if ( $categorize_products == 'yes' ) {
+					if ( $categorize_products == 'true' ) {
 						$term = term_exists( sanitize_title( $tag ), 'product_cat' );
 						if ( $term === 0 && $term === null ) {
 							if ( $cat_id ) {
@@ -403,7 +403,7 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 				foreach ( $product->categories as $category ) {
 					$tag .= isset( $category->name->$default_lang ) ? sanitize_text_field( $category->name->$default_lang ) : '';
 
-					if ( $categorize_products == 'yes' ) {
+					if ( $categorize_products == 'true' ) {
 						$term = term_exists( sanitize_title( $tag ), 'product_cat' );
 						if ( $term === 0 && $term === null ) {
 							if ( $cat_id ) {
@@ -426,7 +426,7 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 					unset( $tag );
 				}
 			}
-			if ($tagging_products === 'yes'){
+			if ($tagging_products === 'true'){
 				wp_set_object_terms( ! empty( $new_product['id'] ) ? $new_product['id'] : 0, $new_product['tags'], 'product_tag', true );
 			}
 

--- a/templates/admin/dropshipping-woocommerce-settings.php
+++ b/templates/admin/dropshipping-woocommerce-settings.php
@@ -10,6 +10,7 @@ $mp_consumer_secret  = isset( $knawat_options['mp_consumer_secret'] ) ? esc_attr
 $token_status        = isset( $knawat_options['token_status'] ) ? esc_attr( $knawat_options['token_status'] ) : 'invalid';
 $product_batch       = isset( $knawat_options['product_batch'] ) ? esc_attr( $knawat_options['product_batch'] ) : 25;
 $categorize_products = isset( $knawat_options['categorize_products'] ) ? esc_attr( $knawat_options['categorize_products'] ) : 'no';
+$tagging_products = isset( $knawat_options['tagging_products'] ) ? esc_attr( $knawat_options['tagging_products'] ) : 'no';
 $dokan_seller        = isset( $knawat_options['dokan_seller'] ) ? esc_attr( $knawat_options['dokan_seller'] ) : - 1;
 ?>
 <div class="knawat_dropshipwc_settings">
@@ -86,6 +87,23 @@ $dokan_seller        = isset( $knawat_options['dokan_seller'] ) ? esc_attr( $kna
                     <p class="description" id="product_batch-description">
 						<?php
 						_e( 'Select yes to fetch product categories', 'dropshipping-woocommerce' );
+						?>
+                    </p>
+                </td>
+            </tr>
+
+            <tr class="knawat_dropshipwc_row">
+                <th scope="row">
+					<?php _e( 'Tagging Products', 'dropshipping-woocommerce' ); ?>
+                </th>
+                <td>
+                    <select name="knawat[tagging_products]" required="required">
+                        <option value="no" <?php selected( 'no', $tagging_products, true ) ?>><?php esc_html_e('No'); ?></option>
+                        <option value="yes" <?php selected( 'yes', $tagging_products, true ) ?>><?php esc_html_e('Yes'); ?></option>
+                    </select>
+                    <p class="description" id="product_tag-description">
+						<?php
+						_e( 'Select yes to fetch product categories as tags', 'dropshipping-woocommerce' );
 						?>
                     </p>
                 </td>

--- a/templates/admin/dropshipping-woocommerce-settings.php
+++ b/templates/admin/dropshipping-woocommerce-settings.php
@@ -9,8 +9,8 @@ $mp_consumer_key     = isset( $knawat_options['mp_consumer_key'] ) ? esc_attr( $
 $mp_consumer_secret  = isset( $knawat_options['mp_consumer_secret'] ) ? esc_attr( $knawat_options['mp_consumer_secret'] ) : '';
 $token_status        = isset( $knawat_options['token_status'] ) ? esc_attr( $knawat_options['token_status'] ) : 'invalid';
 $product_batch       = isset( $knawat_options['product_batch'] ) ? esc_attr( $knawat_options['product_batch'] ) : 25;
-$categorize_products = isset( $knawat_options['categorize_products'] ) ? esc_attr( $knawat_options['categorize_products'] ) : 'no';
-$tagging_products = isset( $knawat_options['tagging_products'] ) ? esc_attr( $knawat_options['tagging_products'] ) : 'no';
+$categorize_products = isset( $knawat_options['categorize_products'] ) ? esc_attr( $knawat_options['categorize_products'] ) : 'false';
+$tagging_products = isset( $knawat_options['tagging_products'] ) ? esc_attr( $knawat_options['tagging_products'] ) : 'false';
 $dokan_seller        = isset( $knawat_options['dokan_seller'] ) ? esc_attr( $knawat_options['dokan_seller'] ) : - 1;
 ?>
 <div class="knawat_dropshipwc_settings">
@@ -81,8 +81,8 @@ $dokan_seller        = isset( $knawat_options['dokan_seller'] ) ? esc_attr( $kna
                 </th>
                 <td>
                     <select name="knawat[categorize_products]" required="required">
-                        <option value="no" <?php selected( 'no', $categorize_products, true ) ?>><?php esc_html_e('No'); ?></option>
-                        <option value="yes" <?php selected( 'yes', $categorize_products, true ) ?>><?php esc_html_e('Yes'); ?></option>
+                        <option value="false" <?php selected( 'false', $categorize_products, true ) ?>><?php esc_html_e('No'); ?></option>
+                        <option value="true" <?php selected( 'true', $categorize_products, true ) ?>><?php esc_html_e('Yes'); ?></option>
                     </select>
                     <p class="description" id="product_batch-description">
 						<?php
@@ -98,8 +98,8 @@ $dokan_seller        = isset( $knawat_options['dokan_seller'] ) ? esc_attr( $kna
                 </th>
                 <td>
                     <select name="knawat[tagging_products]" required="required">
-                        <option value="no" <?php selected( 'no', $tagging_products, true ) ?>><?php esc_html_e('No'); ?></option>
-                        <option value="yes" <?php selected( 'yes', $tagging_products, true ) ?>><?php esc_html_e('Yes'); ?></option>
+                        <option value="false" <?php selected( 'false', $tagging_products, true ) ?>><?php esc_html_e('No'); ?></option>
+                        <option value="true" <?php selected( 'true', $tagging_products, true ) ?>><?php esc_html_e('Yes'); ?></option>
                     </select>
                     <p class="description" id="product_tag-description">
 						<?php


### PR DESCRIPTION
ADD: Added option to import categories as tags or not in the admin settings page.
FIX: Fix in importer according to the above logic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knawat/dropshipping-woocommerce/143)
<!-- Reviewable:end -->
