### PR TITLE
Add support for qTranslate XT plugin as a WordPress multilingual plugin instead of the legacy qTranslate X

### DIFF
--- a/includes/class-dropshipping-woocommerce-common.php
+++ b/includes/class-dropshipping-woocommerce-common.php
@@ -573,18 +573,24 @@ function knawat_dropshipwc_get_activated_plugins() {
 	$active_plugins = array(
 		'featured-image-by-url'         => false,
 		'woocommerce-currency-switcher' => false,
+		'qtranslate-xt'                 => false,
 		'qtranslate-x'                  => false
 	);
 
 	$blog_plugins = get_option( 'active_plugins', array() );
 	$site_plugins = is_multisite() ? (array) maybe_unserialize( get_site_option( 'active_sitewide_plugins' ) ) : array();
 
+	// Check if qTranslate XT is activated
+	if ( in_array( 'qtranslate-xt/qtranslate.php', $blog_plugins ) || isset( $site_plugins['qtranslate-xt/qtranslate.php'] ) ) {
+		$active_plugins['qtranslate-xt'] = true;
+	}
+
 	// Check if qTranslate X is activated
 	if ( in_array( 'qtranslate-x/qtranslate.php', $blog_plugins ) || isset( $site_plugins['qtranslate-x/qtranslate.php'] ) ) {
 		$active_plugins['qtranslate-x'] = true;
 	}
 
-	// Check if Featued image by URL is activated
+	// Check if Featured image by URL is activated
 	if ( in_array( 'featured-image-by-url/featured-image-by-url.php', $blog_plugins ) || isset( $site_plugins['featured-image-by-url/featured-image-by-url.php'] ) ) {
 		$active_plugins['featured-image-by-url'] = true;
 	}

--- a/includes/class-dropshipping-woocommerce-importer.php
+++ b/includes/class-dropshipping-woocommerce-importer.php
@@ -269,7 +269,7 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 
 			$active_plugins = knawat_dropshipwc_get_activated_plugins();
 
-			if ( $active_plugins['qtranslate-x'] ) {
+			if ( $active_plugins['qtranslate-xt'] || $active_plugins['qtranslate-x'] ) {
 				global $q_config;
 				$default_lang = isset( $q_config['default_language'] ) ? sanitize_text_field( $q_config['default_language'] ) : $default_lang;
 				$active_langs = isset( $q_config['enabled_languages'] ) ? $q_config['enabled_languages'] : array();
@@ -291,7 +291,7 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 				$new_product['name']        = isset( $product->name->$default_lang ) ? sanitize_text_field( $product->name->$default_lang ) : '';
 				$new_product['description'] = isset( $product->description->$default_lang ) ? sanitize_textarea_field( $product->description->$default_lang ) : '';
 
-				if ( $active_plugins['qtranslate-x'] && ! empty( $active_langs ) ) {
+				if ( ( $active_plugins['qtranslate-x'] || $active_plugins['qtranslate-xt'] ) && ! empty( $active_langs ) ) {
 
 					$new_product['name']        = '';
 					$new_product['description'] = '';
@@ -365,8 +365,8 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 			$knawat_options      = knawat_dropshipwc_get_options();
 			$categorize_products = isset( $knawat_options['categorize_products'] ) ? esc_attr( $knawat_options['categorize_products'] ) : 'no';
 			$tag 				 = '';
-			
-			if ( $active_plugins['qtranslate-x'] && ! empty( $active_langs ) ) {
+
+			if ( ( $active_plugins['qtranslate-xt'] || $active_plugins['qtranslate-x'] ) && ! empty( $active_langs ) )  {
 				
 				foreach ( $product->categories as $key => $category ) {
 					foreach ( $active_langs as $active_lang ) {
@@ -426,7 +426,7 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 						$temp_variant['id'] = $varient_id;
 						// Update name as its name is added as null in the first time - related to migration task
 						if ( empty( $temp_variant['name'] ) && empty( $new_product['name'] ) ) {
-							if ( $active_plugins['qtranslate-x'] && ! empty( $active_langs ) ) {
+							if ( ( $active_plugins['qtranslate-xt'] || $active_plugins['qtranslate-x'] ) && ! empty( $active_langs ) )  {
 
 								$new_product['name'] = '';
 
@@ -745,7 +745,7 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 			$default_lang   = explode( '_', $default_lang );
 			$default_lang   = $default_lang[0];
 			$active_plugins = knawat_dropshipwc_get_activated_plugins();
-			if ( $active_plugins['qtranslate-x'] ) {
+			if ( $active_plugins['qtranslate-x'] || $active_plugins['qtranslate-xt'] ) {
 				global $q_config;
 				$default_lang = isset( $q_config['default_language'] ) ? sanitize_text_field( $q_config['default_language'] ) : $default_lang;
 				$active_langs = isset( $q_config['enabled_languages'] ) ? $q_config['enabled_languages'] : array();
@@ -761,7 +761,7 @@ if ( class_exists( 'WC_Product_Importer', false ) ) :
 				$formated_value = isset( $lang_object->tr ) ? $lang_object->tr : '';
 			}
 
-			if ( $active_plugins['qtranslate-x'] && ! empty( $active_langs ) ) {
+			if ( ( $active_plugins['qtranslate-x'] || $active_plugins['qtranslate-xt'] ) && ! empty( $active_langs ) ) {
 				$formated_value = '';
 				foreach ( $active_langs as $active_lang ) {
 					if ( isset( $lang_object->$active_lang ) ) {

--- a/includes/knawat-required-plugins.php
+++ b/includes/knawat-required-plugins.php
@@ -58,6 +58,15 @@ function knawat_dropshipwc_register_required_plugins() {
 			'required'     	=> false,
 			'recommended_by'=> 'knawat'
 		);
+
+	$plugins[] = array( //add q-translate-xt in recommended plugins
+		'name'           => esc_html__( 'qTranslate XT', 'dropshipping-woocommerce' ),
+		'slug'           => 'qtranslate-xt',
+		'required'       => false,
+		'source'         => 'https://github.com/qtranslate/qtranslate-xt/archive/master.zip',
+		'recommended_by' => 'knawat'
+	);
+
 	/*
 	 * Array of configuration settings. Amend each line as needed.
 	 *


### PR DESCRIPTION
## :memo: Description
The qTranslate-XT plugin is an eXTended version of qTranslate-X that reviving with a new community since the original plugin is abandoned by its author.
i have added the support for qtranslate-xt in the importer class. to be able to import multilingual products with qtranslate-xt



### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a migration update

### :scroll: Steps to test
1. install qTranslate XT from https://github.com/qtranslate/qtranslate-xt/archive/3.9.1.zip.
2. set your languages
3. start product syncing.

